### PR TITLE
fix book code: fix `strncpy` does not NUL terminate filename

### DIFF
--- a/doc/examples/014/ffmpeg-simple-player/src/DemuxThread.cpp
+++ b/doc/examples/014/ffmpeg-simple-player/src/DemuxThread.cpp
@@ -18,7 +18,7 @@ void DemuxThread::setPlayerCtx(FFmpegPlayerCtx *ctx)
 int DemuxThread::initDemuxThread()
 {
     AVFormatContext *formatCtx = NULL;
-    if (avformat_open_input(&formatCtx, is->filename, NULL, NULL) != 0) {
+    if (avformat_open_input(&formatCtx, is->filename.data(), NULL, NULL) != 0) {
         ff_log_line("avformat_open_input Failed.");
         return -1;
     }
@@ -30,7 +30,7 @@ int DemuxThread::initDemuxThread()
         return -1;
     }
 
-    av_dump_format(formatCtx, 0, is->filename, 0);
+    av_dump_format(formatCtx, 0, is->filename.data(), 0);
 
     if (stream_open(is, AVMEDIA_TYPE_AUDIO) < 0) {
         ff_log_line("open audio stream Failed.");
@@ -104,7 +104,7 @@ int DemuxThread::decode_loop()
             }
 
             if (av_seek_frame(is->formatCtx, stream_index, seek_target, is->seek_flags) < 0) {
-                ff_log_line("%s: error while seeking\n", is->filename);
+                ff_log_line("%s: error while seeking\n", is->filename.data());
             } else {
                 if(is->audioStream >= 0) {
                     is->audioq.packetFlush();

--- a/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.cpp
+++ b/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.cpp
@@ -88,7 +88,7 @@ int FFmpegPlayer::initPlayer()
 {
     // init ctx
     playerCtx.init();
-    strncpy(playerCtx.filename, m_filePath.c_str(), m_filePath.size());
+    playerCtx.filename = m_filePath;
 
     // create demux thread
     m_demuxThread = new DemuxThread;

--- a/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.h
+++ b/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.h
@@ -100,7 +100,7 @@ struct FFmpegPlayerCtx {
     SDL_mutex       *pictq_mutex = nullptr;
     SDL_cond        *pictq_cond = nullptr;
 
-    char            filename[1024];
+    std::string     filename;
 
     SwsContext      *sws_ctx = nullptr;
     SwrContext      *swr_ctx = nullptr;


### PR DESCRIPTION
 - In `FFmpegPlayer.cpp`, `strncpy(playerCtx.filename, m_filePath.c_str(), m_filePath.size());` does not NUL terminate filename. Three solutions: 1) From strncpy(3) example, NUL terminate the result string explicitly. But it's tedious. 2) Use strlcpy(3) but not portable. 3) Use std::string to avoid the pitfall. I prefer the last solution.

   Reference: https://stackoverflow.com/a/1454071/1204713