### PR TITLE
[Bug Fixed] Fix the bug that couldn't display YUV420P video 

### DIFF
--- a/doc/examples/014/ffmpeg-simple-player/src/DemuxThread.cpp
+++ b/doc/examples/014/ffmpeg-simple-player/src/DemuxThread.cpp
@@ -206,7 +206,7 @@ int DemuxThread::stream_open(FFmpegPlayerCtx *is, int media_type)
                     codecCtx->pix_fmt,
                     codecCtx->width,
                     codecCtx->height,
-                    AV_PIX_FMT_RGB24,
+                    AV_PIX_FMT_YUV420P,
                     SWS_BILINEAR,
                     NULL,
                     NULL,

--- a/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.cpp
+++ b/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.cpp
@@ -49,7 +49,7 @@ static void video_display(FFmpegPlayerCtx *is)
 {
     VideoPicture *vp =  &is->pictq[is->pictq_rindex];
     if (vp->bmp && is->imgCb) {
-        is->imgCb(vp->bmp->data[0], is->vCodecCtx->width, is->vCodecCtx->height, is->cbData);
+        is->imgCb(vp->bmp, is->vCodecCtx->width, is->vCodecCtx->height, is->cbData);
     }
 }
 
@@ -75,7 +75,8 @@ FFmpegPlayer::FFmpegPlayer()
 
 void FFmpegPlayer::setFilePath(const char *filePath)
 {
-    m_filePath = filePath;
+    /* to fix the file path copy error */
+    playerCtx.filename = filePath;
 }
 
 void FFmpegPlayer::setImageCb(Image_Cb cb, void *userData)
@@ -88,7 +89,7 @@ int FFmpegPlayer::initPlayer()
 {
     // init ctx
     playerCtx.init();
-    strncpy(playerCtx.filename, m_filePath.c_str(), m_filePath.size());
+    //strncpy(playerCtx.filename, m_filePath.c_str(), m_filePath.size());
 
     // create demux thread
     m_demuxThread = new DemuxThread;

--- a/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.cpp
+++ b/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.cpp
@@ -89,7 +89,7 @@ int FFmpegPlayer::initPlayer()
 {
     // init ctx
     playerCtx.init();
-    //strncpy(playerCtx.filename, m_filePath.c_str(), m_filePath.size());
+
 
     // create demux thread
     m_demuxThread = new DemuxThread;

--- a/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.h
+++ b/doc/examples/014/ffmpeg-simple-player/src/FFmpegPlayer.h
@@ -40,7 +40,7 @@ extern "C" {
 
 #define SDL_AUDIO_BUFFER_SIZE (1024)
 
-typedef void (*Image_Cb)(unsigned char* data, int w, int h, void *userdata);
+typedef void (*Image_Cb)(void *data, int w, int h, void *userdata);
 
 struct VideoPicture {
     AVFrame  *bmp = nullptr;
@@ -53,6 +53,8 @@ enum PauseState {
 };
 
 struct FFmpegPlayerCtx {
+
+    AVFrame *frame = nullptr;
 
     AVFormatContext *formatCtx = nullptr;
 
@@ -100,7 +102,7 @@ struct FFmpegPlayerCtx {
     SDL_mutex       *pictq_mutex = nullptr;
     SDL_cond        *pictq_cond = nullptr;
 
-    char            filename[1024];
+    const char      *filename;
 
     SwsContext      *sws_ctx = nullptr;
     SwrContext      *swr_ctx = nullptr;

--- a/doc/examples/014/ffmpeg-simple-player/src/RenderView.h
+++ b/doc/examples/014/ffmpeg-simple-player/src/RenderView.h
@@ -33,8 +33,6 @@ public:
 
     void onRefresh();
 
-    void setVideoPicture(AVFrame *frame);
-
 private:
     SDL_Window* m_sdlWindow = nullptr;
     SDL_Renderer* m_sdlRender = nullptr;

--- a/doc/examples/014/ffmpeg-simple-player/src/RenderView.h
+++ b/doc/examples/014/ffmpeg-simple-player/src/RenderView.h
@@ -4,6 +4,7 @@
 #include <SDL.h>
 #include <list>
 #include <mutex>
+#include <libavcodec/avcodec.h>
 
 using namespace std;
 
@@ -23,10 +24,16 @@ public:
 
     int initSDL();
 
+    /* this method is deprecated */
     RenderItem* createRGB24Texture(int w, int h);
-    void updateTexture(RenderItem*item, unsigned char *pixelData, int rows);
+
+    RenderItem* createYUV420PTexture(int w, int h);
+
+    void updateTexture(RenderItem*item, void *pixelData, int rows);
 
     void onRefresh();
+
+    void setVideoPicture(AVFrame *frame);
 
 private:
     SDL_Window* m_sdlWindow = nullptr;

--- a/doc/examples/014/ffmpeg-simple-player/src/VideoDecodeThread.h
+++ b/doc/examples/014/ffmpeg-simple-player/src/VideoDecodeThread.h
@@ -15,6 +15,8 @@ public:
 
     void run();
 
+    int copyFrame(AVFrame* oldFrame, AVFrame* newFrame);
+
 private:
     int video_entry();
     int queue_picture(FFmpegPlayerCtx *is, AVFrame *pFrame, double pts);

--- a/doc/examples/014/ffmpeg-simple-player/src/main.cpp
+++ b/doc/examples/014/ffmpeg-simple-player/src/main.cpp
@@ -32,11 +32,11 @@ struct RenderPairData
     RenderView *view = nullptr;
 };
 
-static void FN_DecodeImage_Cb(unsigned char* data, int w, int h, void *userdata)
+static void FN_DecodeImage_Cb(void *data, int w, int h, void *userdata)
 {
     RenderPairData *cbData = (RenderPairData*)userdata;
     if (!cbData->item) {
-        cbData->item = cbData->view->createRGB24Texture(w, h);
+        cbData->item = cbData->view->createYUV420PTexture(w, h);
     }
 
     cbData->view->updateTexture(cbData->item, data, h);


### PR DESCRIPTION
## Change the pixformat from RGB24 to YUV420P to support more media file and fix the file path copy error
> Please see detailed description below for all modifications

### FFmpegPlayer 
- Refactor the method `typedef void (*Image_Cb)(unsigned char* data, int w, int h, void *userdata);` to `typedef void (*Image_Cb)(void* data, int w, int h, void *userdata);` to support AVFrame data passing 
- So the imgCb need pass in parameter `vp->bmp` but `vp->bmp->data[0]`
- And the main.cpp: `static void FN_DecodeImage_Cb(unsigned char* data, int w, int h, void *userdata)` need to be changed
- Change the `char            filename[1024];` to `const char      *filename;` to accept direct assignment from argv[1]

###  RenderView
- Add method `createYUV420PTexture` Implementation 
- Fix the method `updateTexture` implementation to support YUV rendering

### VideoDecodeThread
- change Variable naming : `pFrameRGB` to `pFrameYUV` 
- Implement method `VideoDecodeThread::CopyFrame` to replace `memcpy`
